### PR TITLE
Utils module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ This library makes it easy to specify contracts, providing defensive programming
 It has absolutely no dependencies other than Python's standard library, so it is fully compatible with both Python 3.x and 2.x, and even PyPy.
 
 ### Roadmap
-- Publish it on PyPI
+- Add documentation
 - Enchance the traceback
-- Add an utils module with predicates to make definition of contracts easier
+- Publish it on PyPI

--- a/pycontracts/utils.py
+++ b/pycontracts/utils.py
@@ -1,0 +1,30 @@
+def check_any(args_dict, predicate_func):
+    for arg in args_dict.values():
+        if predicate_func(arg):
+            return True
+    
+    return False
+
+def check_all(args_dict, predicate_func):
+    for arg in args_dict.values():
+        if not predicate_func(arg):
+            return False
+    
+    return True
+
+def drop_fst_arg(args_dict):
+    if "arg__0" in args_dict:
+        del args_dict["arg__0"]
+    return args_dict
+
+def drop_args(args_dict, args_list):
+    for arg in args_list:
+        if arg in args_dict:
+            del args_dict[arg]
+
+    return args_dict
+
+def compose(func_1, func_2):
+    def __inner(arg):
+        return func_1(func_2(arg))
+    return __inner

--- a/pycontracts/utils.py
+++ b/pycontracts/utils.py
@@ -23,8 +23,3 @@ def drop_args(args_dict, args_list):
             del args_dict[arg]
 
     return args_dict
-
-def compose(func_1, func_2):
-    def __inner(arg):
-        return func_1(func_2(arg))
-    return __inner

--- a/tests/test_contracts_classes.py
+++ b/tests/test_contracts_classes.py
@@ -56,7 +56,7 @@ class TestFailingContractClass(unittest.TestCase):
         self.assertRaises(exceptions.PreconditionViolationError,
                             lambda: self.base_class_instance.query(arg2=2, arg1=-3))
 
-    def test_failing_prostcondition_decorator_kwargs(self):
+    def test_failing_postcondition_decorator_kwargs(self):
         self.assertRaises(exceptions.PostconditionViolationError,
                             lambda: self.child_class_instance.query(arg2=2, arg1=3))
 
@@ -64,7 +64,7 @@ class TestFailingContractClass(unittest.TestCase):
         self.assertRaises(exceptions.PreconditionViolationError,
                             lambda: self.base_class_instance.query(2, arg2=-3))
 
-    def test_failing_prostcondition_decorator_mixed(self):
+    def test_failing_postcondition_decorator_mixed(self):
         self.assertRaises(exceptions.PostconditionViolationError,
                             lambda: self.child_class_instance.query(2, arg2=3))
 

--- a/tests/test_contracts_classes.py
+++ b/tests/test_contracts_classes.py
@@ -1,15 +1,11 @@
 import unittest
-from pycontracts import Contract, exceptions
-
-def remove_fst(dictionary):
-    del dictionary["arg__0"]
-    return dictionary
+from pycontracts import Contract, exceptions, utils
 
 class TestClassBase(object):
 
     @Contract.pre_conditions({
         "All arguments should be positive":
-            lambda args: all(map(lambda x: 1 if x > 0 else 0, list(remove_fst(args.all_args).values())))
+            lambda args: utils.check_all(utils.drop_fst_arg(args.all_args), lambda arg: arg > 0)
     })
     def query(self, arg1, arg2):
          return arg1 * arg2

--- a/tests/test_contracts_functions.py
+++ b/tests/test_contracts_functions.py
@@ -1,9 +1,9 @@
 import unittest
-from pycontracts import Contract, exceptions
+from pycontracts import Contract, exceptions, utils
 
 @Contract.pre_conditions({
     "All arguments should be positive":
-        lambda args: all(map(lambda x: 1 if x > 0 else 0, list(args.all_args.values())))
+        lambda args: utils.check_all(args.all_args, lambda arg: arg > 0)
 })
 @Contract.post_conditions({
     "Return value should be positive": lambda ret: ret > 0
@@ -14,7 +14,7 @@ def testable_function(x, y):
 
 @Contract.pre_conditions({
     "All arguments should be positive":
-        lambda args: all(map(lambda x: 1 if x > 0 else 0, list(args.all_args.values())))
+        lambda args: utils.check_all(args.all_args, lambda arg: arg > 0)
 })
 @Contract.post_conditions({
     "Return value should be positive": lambda ret: ret > 0

--- a/tests/test_contracts_functions.py
+++ b/tests/test_contracts_functions.py
@@ -47,14 +47,14 @@ class TestFailingContracts(unittest.TestCase):
         self.assertRaises(exceptions.PreconditionViolationError,
                             lambda: untestable_function(y=2, x=-3))
 
-    def test_failing_prostcondition_decorator_kwargs(self):
+    def test_failing_postcondition_decorator_kwargs(self):
         self.assertRaises(exceptions.PostconditionViolationError,
                             lambda: untestable_function(y=2, x=3))
 
-    def test_failing_precondition_decorator_mixed(self):
+    def test_failing_pecondition_decorator_mixed(self):
         self.assertRaises(exceptions.PreconditionViolationError,
                             lambda: untestable_function(2, y=-3))
 
-    def test_failing_prostcondition_decorator_mixed(self):
+    def test_failing_postcondition_decorator_mixed(self):
         self.assertRaises(exceptions.PostconditionViolationError,
                             lambda: untestable_function(2, y=3))

--- a/tests/test_toggle_contracts.py
+++ b/tests/test_toggle_contracts.py
@@ -1,16 +1,16 @@
 import unittest
-from pycontracts import Contract
+from pycontracts import Contract, utils
 
 
 @Contract.pre_conditions({
     "All arguments should be positive":
-        lambda args: all(map(lambda x: 1 if x > 0 else 0, list(args.all_args.values())))
+        lambda args: utils.check_all(args.all_args, lambda arg: arg > 0)
 })
 @Contract.post_conditions({
-    "Return value should be positive": lambda ret: ret > 0
+    "Return value should be positive": lambda ret: ret[0] > 0 and ret[1] > 0
 })
-def untestable_function(x, y):
-    return - (x * x + y * y)
+def untestable_function(x, y, z, w):
+    return - (x * x + y * y), (z + w)
 
 
 class TestDisabledContracts(unittest.TestCase):
@@ -19,10 +19,10 @@ class TestDisabledContracts(unittest.TestCase):
         Contract.disable_all_tests()
 
     def test_not_failing_precondition_decorator_mixed(self):
-        self.assertEqual(untestable_function(2, y=-3), -13)
+        self.assertEqual(untestable_function(2, 3, z=4, w=-3), (-13, 1))
 
     def test_not_failing_prostcondition_decorator_mixed(self):
-        self.assertEqual(untestable_function(2, y=3), -13)
+        self.assertEqual(untestable_function(2, 3, z=4, w=-3), (-13, 1))
 
     def tearDown(self):
         Contract.enable_all_tests()

--- a/tests/test_toggle_contracts.py
+++ b/tests/test_toggle_contracts.py
@@ -21,7 +21,7 @@ class TestDisabledContracts(unittest.TestCase):
     def test_not_failing_precondition_decorator_mixed(self):
         self.assertEqual(untestable_function(2, 3, z=4, w=-3), (-13, 1))
 
-    def test_not_failing_prostcondition_decorator_mixed(self):
+    def test_not_failing_postcondition_decorator_mixed(self):
         self.assertEqual(untestable_function(2, 3, z=4, w=-3), (-13, 1))
 
     def tearDown(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+import unittest
+from pycontracts import utils
+
+class TestUtils(unittest.TestCase):
+    
+    def setUp(self):
+        self.dictionary = {
+            "arg__0": 12,
+            "arg__1": 32,
+            "some_other_argument": 128
+            }
+
+    def test_check_any(self):
+        self.assertEqual(utils.check_any(self.dictionary, lambda arg: arg is list), False)
+
+    def test_check_all(self):
+        self.assertEqual(utils.check_all(self.dictionary, lambda arg: arg > 0), True)
+
+    def test_drop_fst_arg(self):
+        self.assertDictEqual(utils.drop_fst_arg(self.dictionary),
+                             {"arg__1": 32, "some_other_argument": 128})
+
+    def test_drop_args(self):
+        self.assertDictEqual(utils.drop_args(self.dictionary, ["some_other_argument", "arg__3"]),
+                             {"arg__0": 12, "arg__1": 32})
+
+    def tearDown(self):
+        self.dictionary.clear()
+

--- a/tests/test_utils_drop_args.py
+++ b/tests/test_utils_drop_args.py
@@ -1,0 +1,23 @@
+import unittest
+from pycontracts import Contract, utils
+
+
+@Contract.pre_conditions({
+    "All but 'w'/last argument should be positive":
+        lambda args: utils.check_all(utils.drop_args(args.all_args, ["w", "arg__3"]),
+                                     lambda arg: arg > 0)
+})
+@Contract.post_conditions({
+    "2nd Return value should be positive": lambda ret: ret[1] > 0
+})
+def untestable_function(x, y, z, w):
+    return - (x * x + y * y), (z + w)
+
+
+class TestUtilsDropArgs(unittest.TestCase):
+
+    def test_successful_precondition_decorator_mixed(self):
+        self.assertEqual(untestable_function(2, 3, z=4, w=-3), (-13, 1))
+
+    def test_successful_prostcondition_decorator_mixed(self):
+        self.assertEqual(untestable_function(2, 3, z=4, w=-3), (-13, 1))

--- a/tests/test_utils_drop_args.py
+++ b/tests/test_utils_drop_args.py
@@ -16,8 +16,20 @@ def untestable_function(x, y, z, w):
 
 class TestUtilsDropArgs(unittest.TestCase):
 
+    def test_successful_precondition_decorator_args(self):
+        self.assertEqual(untestable_function(2, 3, 4, -3), (-13, 1))
+
+    def test_successful_postcondition_decorator_args(self):
+        self.assertEqual(untestable_function(2, 3, 4, -3), (-13, 1))
+
+    def test_successful_precondition_decorator_kwargs(self):
+        self.assertEqual(untestable_function(x=2, y=3, z=4, w=-3), (-13, 1))
+
+    def test_successful_postcondition_decorator_kwargs(self):
+        self.assertEqual(untestable_function(x=2, y=3, z=4, w=-3), (-13, 1))
+
     def test_successful_precondition_decorator_mixed(self):
         self.assertEqual(untestable_function(2, 3, z=4, w=-3), (-13, 1))
 
-    def test_successful_prostcondition_decorator_mixed(self):
+    def test_successful_postcondition_decorator_mixed(self):
         self.assertEqual(untestable_function(2, 3, z=4, w=-3), (-13, 1))


### PR DESCRIPTION
Add a utils module to ease the writing of contract conditions. For now, `check_all`, `check_any` predicates and `drop_fst_arg` and `drop_args` functions are implemented. Tests are included.